### PR TITLE
Add dryrun option to MineflayerLog

### DIFF
--- a/lib/mineflayer-log.js
+++ b/lib/mineflayer-log.js
@@ -12,6 +12,7 @@ class MineflayerLog {
    * @param {object} opts
    * @param {string} opts.version Target minecraft version
    * @param {string} opts.outputDirectory Directory to write packets to
+   * @param {Boolean} opts.dryRun Whether to skip saving packets (defaults to false)
    */
   constructor (opts) {
     this.version = opts.version
@@ -20,6 +21,7 @@ class MineflayerLog {
     this.kindCounter = {}
     this.kindPromise = {}
     this.maxPerKind = opts.maxPerKind || 5
+    this.dryRun = opts.dryRun ?? false
   }
 
   start (host, port, username = 'nmptestbot') {
@@ -29,7 +31,11 @@ class MineflayerLog {
       username,
       version: this.version
     })
-    this.setupPacketLog(this.bot._client)
+    if (this.dryRun) {
+      this.setupPacketLogDryRun(this.bot._client)
+    } else {
+      this.setupPacketLog(this.bot._client)
+    }
   }
 
   setupPacketLog (client) {
@@ -48,6 +54,19 @@ class MineflayerLog {
       await this.kindPromise[meta.name]
       await fsP.writeFile(path.join(PACKET_DIRECTORY, 'from-server', meta.name, '' + n + '.raw'), buffer)
       await fsP.writeFile(path.join(PACKET_DIRECTORY, 'from-server', meta.name, '' + n + '.json'), JSON.stringify(data, null, 2))
+    })
+  }
+
+  setupPacketLogDryRun (client) {
+    client.on('packet', async (data, meta, buffer) => {
+      if (meta.state !== 'play') return
+      if (this.kindCounter[meta.name] === undefined) {
+        this.kindCounter[meta.name] = 0
+      }
+      if (this.kindCounter[meta.name] >= this.maxPerKind) {
+        return
+      }
+      this.kindCounter[meta.name] += 1
     })
   }
 }

--- a/lib/testCoverage.js
+++ b/lib/testCoverage.js
@@ -1,0 +1,77 @@
+/**
+ * This file is to see what packets were collected, and which were not
+ */
+
+const path = require('path')
+const fs = require('fs')
+const fsP = fs.promises
+const util = require('util')
+const minecraftWrap = require('minecraft-wrap')
+const MineflayerLog = require('../lib/mineflayer-log')
+
+const SERVER_DIRECTORY = path.resolve('server')
+const SERVER_PATH = path.join(SERVER_DIRECTORY, 'server.jar')
+
+const downloadServer = util.promisify(minecraftWrap.download)
+
+/**
+ * Stat stuff to see if it exists
+ * @param {string} path
+ */
+async function fileExists (path) {
+  try {
+    await fsP.stat(path)
+    return true
+  } catch (err) {
+    return false
+  }
+}
+
+(async function main () {
+  const version = process.argv[2]
+  if (!version) {
+    console.error('version needed as first argument!')
+    process.exit(1)
+  }
+  if (!await fileExists(SERVER_DIRECTORY)) await fsP.mkdir(SERVER_DIRECTORY)
+  console.log('downloading server')
+  await downloadServer(version, SERVER_PATH)
+  console.log('done')
+
+  console.log('starting server')
+  const server = new minecraftWrap.WrapServer(SERVER_PATH, SERVER_DIRECTORY, {
+    maxMem: 2048
+  })
+  server.on('line', line => console.log('server:', line))
+  await util.promisify(server.startServer.bind(server))({
+    'online-mode': false,
+    difficulty: 'normal',
+    'spawn-protection': 'off'
+  })
+  console.log('server started')
+  const packetLogger = new MineflayerLog({ version, dryRun: true })
+  packetLogger.start('localhost', 25565)
+  packetLogger.bot.on('spawn', () => {
+    console.log('bot connected')
+    server.writeServer('time set night\n') // allow bot to get murdered by a zombie or something
+  })
+  setTimeout(() => {
+    const mcData = require('minecraft-data')(packetLogger.bot.version)
+    packetLogger.bot.quit()
+
+    // record packets
+    const collectedPackets = Object.keys(packetLogger.kindCounter)
+    const allPackets = Object.keys(mcData.protocol.play.toClient.types)
+      .filter(o => o.startsWith('packet_'))
+      .map(o => o.replace('packet_', ''))
+
+    // write packet data
+    const data = {
+      collected: collectedPackets,
+      missing: allPackets.filter(o => !collectedPackets.includes(o))
+    }
+
+    fs.writeFileSync('packets_info.json', JSON.stringify(data, null, 2))
+    server.stopServer(() => process.exit(0))
+  }, 20 * 1000)
+}())


### PR DESCRIPTION
This is in order to close https://github.com/PrismarineJS/prismarine-packet-dumper/issues/7 , 
when `lib/testCoverage.js`, the output will look like this: https://gist.github.com/u9g/c0963e89cc5fe49282b968b789972ef0

this should be added to be run on commit to this repo eventually so we can have up to date stats on how many we still need