### PR TITLE
Add dumpPackets.js which has coverage & dumping

### DIFF
--- a/bin/dumpPackets.js
+++ b/bin/dumpPackets.js
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+const minecraftWrap = require('minecraft-wrap')
+const fs = require('fs')
+const fsP = fs.promises
+const path = require('path')
+const util = require('util')
+const MineflayerLog = require('../lib/mineflayer-log')
+const rimraf = util.promisify(require('rimraf'))
+
+const argv = require('yargs/yargs')(process.argv.slice(2))
+  .usage('Usage: $0 [options]')
+  .version(false) // disable default version command
+  .option('version', {
+    alias: ['v', 'ver'],
+    description: 'The mc version to dump',
+    string: true,
+    demandOption: true
+  })
+  .option('packetsSaveDir', {
+    description: 'Where to save the dumped packets',
+    default: 'packets',
+    string: true,
+    coerce: path.resolve
+  })
+  .option('h', {
+    alias: 'help',
+    description: 'Display help message'
+  })
+  .option('dryrun', {
+    alias: 'd',
+    default: false,
+    boolean: true,
+    description: "Run dumper but don't save packets",
+    implies: 'saveStatistics'
+  })
+  .option('saveStatistics', {
+    alias: ['s', 'stats'],
+    description: 'Save statistics generated?',
+    boolean: true,
+    default: false,
+    implies: 'statsFormat'
+  })
+  .option('statsFormat', {
+    description: 'File format for stats',
+    choices: ['md', 'json', 'both'],
+    requiresArg: 'saveStatistics'
+  })
+  .option('mdStatsSaveDir', {
+    string: true,
+    default: '.',
+    description: 'Where to save statistics file',
+    requiresArg: 'saveStatistics',
+    coerce: path.resolve
+  })
+  .option('jsonStatsSaveDir', {
+    string: true,
+    default: '.',
+    description: 'Where to save statistics file',
+    requiresArg: 'saveStatistics',
+    coerce: path.resolve
+  })
+  .option('serverDirectory', {
+    alias: 'servDir',
+    description: 'Where the dumper stores the server.jar',
+    default: 'server',
+    coerce: path.resolve
+  })
+  .help('help')
+  // show examples of application in action.
+  // final message to display when successful.
+  .epilog('for more information visit https://discord.gg/tWaPBNtkaq')
+  // disable showing help on failures, provide a final message
+  // to display for errors.
+  .showHelpOnFail(false, 'whoops, something went wrong! get more info with --help')
+  .argv
+
+const SERVER_DIRECTORY = argv.serverDirectory
+const SERVER_PATH = path.join(SERVER_DIRECTORY, 'server.jar')
+const PACKET_DIRECTORY = argv.packetsSaveDir
+
+const downloadServer = util.promisify(minecraftWrap.download)
+
+/**
+ * Stat stuff to see if it exists
+ * @param {string} path
+ */
+async function fileExists (path) {
+  try {
+    await fsP.stat(path)
+    return true
+  } catch (err) {
+    return false
+  }
+}
+
+(async function main () {
+  const version = argv.version
+  if (!version) {
+    console.error('version needed as first argument!')
+    process.exit(1)
+  }
+  if (!await fileExists(SERVER_DIRECTORY)) await fsP.mkdir(SERVER_DIRECTORY)
+  console.log('downloading server')
+  await downloadServer(version, SERVER_PATH)
+  console.log('done')
+
+  if (await fileExists(PACKET_DIRECTORY)) {
+    console.log('deleting old packet log')
+    await rimraf(PACKET_DIRECTORY)
+  }
+  await fsP.mkdir(PACKET_DIRECTORY)
+  await fsP.mkdir(path.join(PACKET_DIRECTORY, 'from-server'))
+  await fsP.mkdir(path.join(PACKET_DIRECTORY, 'from-client'))
+
+  console.log('starting server')
+  const server = new minecraftWrap.WrapServer(SERVER_PATH, SERVER_DIRECTORY, {
+    maxMem: 2048
+  })
+  server.on('line', line => console.log('server:', line))
+  await util.promisify(server.startServer.bind(server))({
+    'online-mode': false,
+    difficulty: 'normal',
+    'spawn-protection': 'off'
+  })
+  console.log('server started')
+  const packetLogger = new MineflayerLog({ version, outputDirectory: PACKET_DIRECTORY, dryRun: argv.dryrun })
+  packetLogger.start('localhost', 25565)
+  packetLogger.bot.on('spawn', () => {
+    console.log('bot connected')
+    server.writeServer('time set night\n') // allow bot to get murdered by a zombie or something
+  })
+  setTimeout(() => {
+    const mcData = require('minecraft-data')(packetLogger.bot.version)
+    packetLogger.bot.quit()
+    server.stopServer(() => process.exit(0))
+
+    if (argv.saveStatistics) {
+    // record packets
+      const collectedPackets = Object.keys(packetLogger.kindCounter)
+      const allPackets = Object.keys(mcData.protocol.play.toClient.types)
+        .filter(o => o.startsWith('packet_'))
+        .map(o => o.replace('packet_', ''))
+
+      // write packet data
+      const data = {
+        collected: collectedPackets,
+        missing: allPackets.filter(o => !collectedPackets.includes(o))
+      }
+      if (argv.statsFormat === 'both') {
+        fs.writeFileSync(path.join(argv.mdStatsSaveDir, 'README.md'), makeMarkdown(data, version))
+        fs.writeFileSync(path.join(argv.jsonStatsSaveDir, 'packets_info.json'), JSON.stringify(data, null, 2))
+      } else if (argv.statsFormat === 'md') {
+        fs.writeFileSync(path.join(argv.mdStatsSaveDir, 'README.md'), makeMarkdown(data, version))
+      } else if (argv.statsFormat === 'json') {
+        fs.writeFileSync(path.join(argv.jsonStatsSaveDir, 'packets_info.json'), JSON.stringify(data, null, 2))
+      }
+    }
+  }, 60 * 1000)
+}())
+
+const makeDropdownStart = (name, arr) => {
+  arr.push(`<details><summary>${name}</summary>`)
+  arr.push('<p>')
+  arr.push('')
+}
+const makeDropdownEnd = (arr) => {
+  arr.push('')
+  arr.push('</p>')
+  arr.push('</details>')
+}
+
+function makeMarkdown (data, version) {
+  const str = []
+  const { collected, missing } = data
+
+  makeDropdownStart(`Collected (${collected.length})`, str)
+  str.push('| Packet |')
+  str.push('| --- |')
+  collected.forEach(elem => {
+    str.push(`| ${elem} |`)
+  })
+  makeDropdownEnd(str)
+
+  makeDropdownStart(`Missing (${missing.length})`, str)
+  str.push('| Packet |')
+  str.push('| --- |')
+  missing.forEach(elem => {
+    str.push(`| ${elem} |`)
+  })
+  makeDropdownEnd(str)
+
+  return str.join('\n')
+}

--- a/lib/mineflayer-log.js
+++ b/lib/mineflayer-log.js
@@ -16,7 +16,7 @@ class MineflayerLog {
    */
   constructor (opts) {
     this.version = opts.version
-    this.outputDirectory = opts.outputDirectory
+    this.outputDirectory = opts.outputDirectory ?? PACKET_DIRECTORY
     this.bot = null
     this.kindCounter = {}
     this.kindPromise = {}
@@ -44,9 +44,12 @@ class MineflayerLog {
         buffer = fullBuffer
       }
       if (meta.state !== 'play') return
+      if (meta.name === 'difficulty') {
+        console.log()
+      }
       if (this.kindCounter[meta.name] === undefined) {
         this.kindCounter[meta.name] = 0
-        this.kindPromise[meta.name] = fsP.mkdir(path.join(PACKET_DIRECTORY, 'from-server', meta.name))
+        this.kindPromise[meta.name] = fsP.mkdir(path.join(this.outputDirectory, 'from-server', meta.name))
       }
       if (this.kindCounter[meta.name] >= this.maxPerKind) {
         return
@@ -55,8 +58,8 @@ class MineflayerLog {
       const n = this.kindCounter[meta.name]
 
       await this.kindPromise[meta.name]
-      await fsP.writeFile(path.join(PACKET_DIRECTORY, 'from-server', meta.name, '' + n + '.raw'), buffer)
-      await fsP.writeFile(path.join(PACKET_DIRECTORY, 'from-server', meta.name, '' + n + '.json'), JSON.stringify(data, null, 2))
+      await fsP.writeFile(path.join(this.outputDirectory, 'from-server', meta.name, '' + n + '.raw'), buffer)
+      await fsP.writeFile(path.join(this.outputDirectory, 'from-server', meta.name, '' + n + '.json'), JSON.stringify(data, null, 2))
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "got": "^11.5.0",
     "minecraft-wrap": "^1.2.3",
     "mineflayer": "^3.0.0",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "yargs": "^16.2.0"
   },
   "devDependencies": {
     "jest": "^26.1.0",
@@ -35,8 +36,6 @@
     "prismarine"
   ],
   "bin": {
-    "generateMinecraftPackets": "./bin/generateLogs.js",
-    "generatePacketDumperCoverage": "./bin/testCoverage.js",
-    "verifyMinecraftPackets": "./bin/verifyPackets.js"
+    "dumpPackets": "./bin/dumpPackets.js"
   }
 }


### PR DESCRIPTION
This pr aims to combine coverage and dumping and add much more configuration options, so that if you want stats from your packet dump, you don't have to run twice. (and if you want md, json, and packets, you won't have to run thrice)