### PR TITLE
Major refactor of dump packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,20 @@ If you would like to use this without cloning from github, you can install it gl
 
 ## API
 
-TODO, for now, see jsdoc
+### For [`bin/dumpPackets.js`](bin/dumpPackets.js)
+
+```
+$ node dumpPackets.js  --help
+Usage: dumpPackets.js [options]
+
+Options:
+  -v, --version, --ver          The mc version to dump       [string] [required]
+  -o, --outputFolder, --output  Where to save the dumped packets
+                                                    [string] [default: "output"]
+  -h, --help                    Show help                              [boolean]
+  -d, --dryrun                  Run dumper but only save stats files
+                                                      [boolean] [default: false]
+
+for more information visit https://discord.gg/tWaPBNtkaq
+```
+### For rest: TODO, for now, see jsdoc

--- a/bin/dumpPackets.js
+++ b/bin/dumpPackets.js
@@ -5,7 +5,7 @@ const fsP = fs.promises
 const path = require('path')
 const util = require('util')
 const MineflayerLog = require('../lib/mineflayer-log')
-const rimraf = util.promisify(require('rimraf'))
+const { makeMarkdown, parsePacketCounter } = require('../lib/stats-helper')
 
 const argv = require('yargs/yargs')(process.argv.slice(2))
   .usage('Usage: $0 [options]')
@@ -16,9 +16,10 @@ const argv = require('yargs/yargs')(process.argv.slice(2))
     string: true,
     demandOption: true
   })
-  .option('packetsSaveDir', {
+  .option('outputFolder', {
+    alias: ['o', 'output'],
     description: 'Where to save the dumped packets',
-    default: 'packets',
+    default: 'output',
     string: true,
     coerce: path.resolve
   })
@@ -30,46 +31,19 @@ const argv = require('yargs/yargs')(process.argv.slice(2))
     alias: 'd',
     default: false,
     boolean: true,
-    description: "Run dumper but don't save packets",
-    implies: 'saveStatistics'
-  })
-  .option('saveStatistics', {
-    alias: ['s', 'stats'],
-    description: 'Save statistics generated?',
-    boolean: true,
-    default: false,
-    implies: 'statsFormat'
-  })
-  .option('statsFormat', {
-    description: 'File format for stats',
-    choices: ['md', 'json', 'both'],
-    requiresArg: 'saveStatistics'
+    description: "Run dumper but don't save packets"
   })
   .option('mdStatsSaveDir', {
     string: true,
     default: '.',
     description: 'Where to save statistics file',
-    requiresArg: 'saveStatistics',
     coerce: path.resolve
   })
   .option('jsonStatsSaveDir', {
     string: true,
     default: '.',
     description: 'Where to save statistics file',
-    requiresArg: 'saveStatistics',
     coerce: path.resolve
-  })
-  .option('serverDirectory', {
-    alias: 'servDir',
-    description: 'Where the dumper stores the server.jar',
-    default: 'server',
-    coerce: path.resolve
-  })
-  .option('delTempFiles', {
-    alias: 't',
-    description: 'delete "server/", "versions/", "launcher_profiles.json"',
-    default: false,
-    boolean: true
   })
   .help('help')
   // show examples of application in action.
@@ -80,9 +54,9 @@ const argv = require('yargs/yargs')(process.argv.slice(2))
   .showHelpOnFail(false, 'whoops, something went wrong! get more info with --help')
   .argv
 
-const SERVER_DIRECTORY = argv.serverDirectory
+const SERVER_DIRECTORY = path.resolve('temp')
 const SERVER_PATH = path.join(SERVER_DIRECTORY, 'server.jar')
-const PACKET_DIRECTORY = argv.packetsSaveDir
+const PACKET_DIRECTORY = argv.outputFolder
 
 const downloadServer = util.promisify(minecraftWrap.download)
 
@@ -99,107 +73,100 @@ async function fileExists (path) {
   }
 }
 
-(async function main () {
-  const version = argv.version
-  if (!version) {
-    console.error('version needed as first argument!')
-    process.exit(1)
-  }
-  if (!await fileExists(SERVER_DIRECTORY)) await fsP.mkdir(SERVER_DIRECTORY)
-  console.log('downloading server')
-  await downloadServer(version, SERVER_PATH)
-  console.log('done')
+async function deleteIfExists (path) {
+  if (!await fileExists(path)) return
+  await fsP.rm(path, { recursive: true, force: true })
+}
 
-  if (await fileExists(PACKET_DIRECTORY)) {
-    console.log('deleting old packet log')
-    await rimraf(PACKET_DIRECTORY)
-  }
+async function setupDirectories () {
+  console.log('deleting old packets & metadata')
+  await deleteIfExists(PACKET_DIRECTORY)
+  await deleteIfExists(path.resolve('packets_info.json'))
+  await deleteIfExists(path.resolve('README.md'))
+
   await fsP.mkdir(PACKET_DIRECTORY)
   await fsP.mkdir(path.join(PACKET_DIRECTORY, 'from-server'))
   await fsP.mkdir(path.join(PACKET_DIRECTORY, 'from-client'))
+}
 
+async function downloadMCServer (version) {
+  await deleteIfExists(SERVER_DIRECTORY)
+  console.log('downloading server')
+  await downloadServer(version, SERVER_PATH)
+  console.log('done')
+}
+
+async function startServer () {
   console.log('starting server')
   const server = new minecraftWrap.WrapServer(SERVER_PATH, SERVER_DIRECTORY, {
     maxMem: 2048
   })
-  server.on('line', line => console.log('server:', line))
+
+  server.on('line', line => console.log(`server: ${line}`))
   await util.promisify(server.startServer.bind(server))({
     'online-mode': false,
     difficulty: 'normal',
     'spawn-protection': 'off'
   })
   console.log('server started')
+  return server
+}
+
+async function startMineflayer (version) {
   const packetLogger = new MineflayerLog({ version, outputDirectory: PACKET_DIRECTORY, dryRun: argv.dryrun })
   packetLogger.start('localhost', 25565)
-  packetLogger.bot.on('spawn', () => {
+  return packetLogger
+}
+
+async function cleanup () {
+  await fsP.rm(SERVER_DIRECTORY, { recursive: true, force: true })
+  await fsP.rm(path.resolve('versions'), { recursive: true, force: true })
+  await fsP.rm(path.resolve('launcher_accounts.json'), { force: true })
+}
+
+async function makeStats (packetLogger, version) {
+  const { collectedPackets, allPackets } = parsePacketCounter(version, packetLogger.kindCounter)
+  // write packet data
+  const data = {
+    collected: collectedPackets,
+    missing: allPackets.filter(o => !collectedPackets.includes(o))
+  }
+
+  await fsP.writeFile(path.join(argv.outputFolder, 'packets_info.json'), JSON.stringify(data, null, 2))
+  await fsP.writeFile(path.join(argv.outputFolder, 'README.md'), makeMarkdown(data))
+}
+
+function asyncStopServer (server) {
+  return new Promise((resolve, reject) => server.stopServer(resolve))
+}
+
+// Logic for mineflayer bot to generate packets with
+async function generatePackets (server, bot) {
+  bot.once('spawn', () => {
     console.log('bot connected')
     server.writeServer('time set night\n') // allow bot to get murdered by a zombie or something
   })
-  setTimeout(async () => {
-    const mcData = require('minecraft-data')(packetLogger.bot.version)
-    packetLogger.bot.quit()
-    await new Promise((resolve, reject) => server.stopServer(resolve))
-
-    if (argv.saveStatistics) {
-    // record packets
-      const collectedPackets = Object.keys(packetLogger.kindCounter)
-      const allPackets = Object.keys(mcData.protocol.play.toClient.types)
-        .filter(o => o.startsWith('packet_'))
-        .map(o => o.replace('packet_', ''))
-
-      // write packet data
-      const data = {
-        collected: collectedPackets,
-        missing: allPackets.filter(o => !collectedPackets.includes(o))
-      }
-      if (argv.statsFormat === 'both') {
-        fs.writeFileSync(path.join(argv.mdStatsSaveDir, 'README.md'), makeMarkdown(data, version))
-        fs.writeFileSync(path.join(argv.jsonStatsSaveDir, 'packets_info.json'), JSON.stringify(data, null, 2))
-      } else if (argv.statsFormat === 'md') {
-        fs.writeFileSync(path.join(argv.mdStatsSaveDir, 'README.md'), makeMarkdown(data, version))
-      } else if (argv.statsFormat === 'json') {
-        fs.writeFileSync(path.join(argv.jsonStatsSaveDir, 'packets_info.json'), JSON.stringify(data, null, 2))
-      }
-    }
-
-    if (argv.delTempFiles) {
-      await fsP.rm(SERVER_DIRECTORY, { recursive: true, force: true })
-      await fsP.rm(path.resolve('versions'), { recursive: true, force: true })
-      await fsP.rm(path.resolve('launcher_accounts.json'), { recursive: true, force: true })
-    }
-  }, 60 * 1000)
-}())
-
-const makeDropdownStart = (name, arr) => {
-  arr.push(`<details><summary>${name}</summary>`)
-  arr.push('<p>')
-  arr.push('')
-}
-const makeDropdownEnd = (arr) => {
-  arr.push('')
-  arr.push('</p>')
-  arr.push('</details>')
+  await new Promise((resolve, reject) => setTimeout(resolve, 10 * 1000)) // wait a minute to get packets
 }
 
-function makeMarkdown (data, version) {
-  const str = []
-  const { collected, missing } = data
-
-  makeDropdownStart(`Collected (${collected.length})`, str)
-  str.push('| Packet |')
-  str.push('| --- |')
-  collected.forEach(elem => {
-    str.push(`| ${elem} |`)
-  })
-  makeDropdownEnd(str)
-
-  makeDropdownStart(`Missing (${missing.length})`, str)
-  str.push('| Packet |')
-  str.push('| --- |')
-  missing.forEach(elem => {
-    str.push(`| ${elem} |`)
-  })
-  makeDropdownEnd(str)
-
-  return str.join('\n')
+async function main () {
+  // setup
+  const version = argv.version
+  await downloadMCServer(version) // download server
+  await setupDirectories() // delete old directories
+  // start client/server
+  const server = await startServer() // start server
+  const packetLogger = await startMineflayer(version) // start mineflayer
+  // generate packets
+  const { bot } = packetLogger
+  await generatePackets(server, bot)
+  // stop client/server
+  bot.quit()
+  await asyncStopServer(server)
+  // make stats files
+  await makeStats(packetLogger, version)
+  // delete temp files
+  await cleanup()
 }
+
+main()

--- a/bin/generateLogs.js
+++ b/bin/generateLogs.js
@@ -4,7 +4,6 @@ const path = require('path')
 const fs = require('fs')
 const fsP = fs.promises
 const util = require('util')
-const rimraf = util.promisify(require('rimraf'))
 const minecraftWrap = require('minecraft-wrap')
 const MineflayerLog = require('../lib/mineflayer-log')
 
@@ -40,7 +39,7 @@ async function fileExists (path) {
 
   if (await fileExists(PACKET_DIRECTORY)) {
     console.log('deleting old packet log')
-    await rimraf(PACKET_DIRECTORY)
+    await fsP.rm(PACKET_DIRECTORY, { recursive: true, force: true })
   }
   await fsP.mkdir(PACKET_DIRECTORY)
   await fsP.mkdir(path.join(PACKET_DIRECTORY, 'from-server'))

--- a/lib/stats-helper.js
+++ b/lib/stats-helper.js
@@ -1,0 +1,46 @@
+const makeDropdownStart = (name, arr) => {
+  arr.push(`<details><summary>${name}</summary>`)
+  arr.push('<p>')
+  arr.push('')
+}
+const makeDropdownEnd = (arr) => {
+  arr.push('')
+  arr.push('</p>')
+  arr.push('</details>')
+}
+
+function makeMarkdown (data) {
+  const str = []
+  const { collected, missing } = data
+
+  makeDropdownStart(`Collected (${collected.length})`, str)
+  str.push('| Packet |')
+  str.push('| --- |')
+  collected.forEach(elem => {
+    str.push(`| ${elem} |`)
+  })
+  makeDropdownEnd(str)
+
+  makeDropdownStart(`Missing (${missing.length})`, str)
+  str.push('| Packet |')
+  str.push('| --- |')
+  missing.forEach(elem => {
+    str.push(`| ${elem} |`)
+  })
+  makeDropdownEnd(str)
+
+  return str.join('\n')
+}
+
+function parsePacketCounter (version, kindCounter) {
+  const mcData = require('minecraft-data')(version)
+  // record packets
+  return {
+    collectedPackets: Object.keys(kindCounter),
+    allPackets: Object.keys(mcData.protocol.play.toClient.types)
+      .filter(o => o.startsWith('packet_'))
+      .map(o => o.replace('packet_', ''))
+  }
+}
+
+module.exports = { makeMarkdown, parsePacketCounter }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "got": "^11.5.0",
     "minecraft-wrap": "^1.2.3",
     "mineflayer": "^3.0.0",
-    "rimraf": "^3.0.2",
     "yargs": "^16.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# Changes made:

* remove `rimraf`
* make `lib/stats-helper.js`
* abstract all logic away from main function into individual functions
* delete options: `saveStatistics`, `saveStatistics`, `serverDirectory`, `delTempFiles`, `mdStatsSaveDir`, `jsonStatsSaveDir`
* add option: `output / o`
* put server into temp folder (since it's deleted when the script is done)
* add help command to readme
* no longer makes folder for packets if dryrun is true
* new final structure: 
```
output/README.md
output/packets_info.json
output/packets/(from-server/to-server)
```